### PR TITLE
stud-175 authorization for chat

### DIFF
--- a/app/mapUrls.go
+++ b/app/mapUrls.go
@@ -4,17 +4,14 @@ import (
 	"chat/messaging/delivery/http"
 	roomHttp "chat/room/delivery/http"
 	"github.com/gin-gonic/gin"
-	"math/rand"
-	"strconv"
 )
 
 func mapChatUrls(mw Middleware, r *gin.Engine, mh *http.MessageHandler) {
 
 	r.GET("/chat/:roomID", func(c *gin.Context) {
 		roomID := c.Param("roomID")
-		userID := strconv.Itoa(rand.Int())
 		ctx := c.Request.Context()
-		mh.ServeWs(c.Writer, c.Request, roomID, userID, ctx)
+		mh.ServeWs(c.Writer, c.Request, roomID, ctx)
 	})
 	router := r.Group("/api")
 	router.Use(mw.AuthMiddleware())

--- a/messaging/delivery/http/chat_delivery.go
+++ b/messaging/delivery/http/chat_delivery.go
@@ -170,7 +170,7 @@ func (c *connection) write(mt int, payload []byte) error {
 
 // ServeWs is the handleFunc for connecting to a room's websocket. A user must be authorized, i.e. already added to
 // the room before he can connect to the room. Otherwise, returns 401.
-func (h *MessageHandler) ServeWs(w http.ResponseWriter, r *http.Request, roomID string, userID string, ctx context.Context) {
+func (h *MessageHandler) ServeWs(w http.ResponseWriter, r *http.Request, roomID string, ctx context.Context) {
 
 	tokenParam, ok := r.URL.Query()["token"]
 
@@ -200,7 +200,7 @@ func (h *MessageHandler) ServeWs(w http.ResponseWriter, r *http.Request, roomID 
 		return
 	}
 	c := &connection{send: make(chan Event), ws: ws}
-	s := subscription{c, roomID, userID}
+	s := subscription{c, roomID, standardClaims.Issuer}
 	if authorized {
 		mainHub.Register <- s
 	}

--- a/messaging/delivery/http/chat_delivery_test.go
+++ b/messaging/delivery/http/chat_delivery_test.go
@@ -52,7 +52,6 @@ func TestMessageSending(t *testing.T) {
 		Issuer:    "1",                               // reserved claim
 	})
 	signedToken, err := token.SignedString([]byte(os.Getenv("SECRET_KEY")))
-
 	var tokenQuery = fmt.Sprintf("?token=%s", signedToken)
 	var validChatRoomID = "1"
 	var invalidChatRoomID =  "2"
@@ -68,7 +67,13 @@ func TestMessageSending(t *testing.T) {
 			assert.Fail(t, err.Error())
 		}
 
-		ws, _, err := websocket.DefaultDialer.Dial(fmt.Sprintf(chatRoomPath, addr.String(), validChatRoomID, tokenQuery), nil)
+		token2 := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.StandardClaims{
+			Issuer:    "2",
+		})
+		signedToken2, err := token2.SignedString([]byte(os.Getenv("SECRET_KEY")))
+		tokenQuery2 := fmt.Sprintf("?token=%s", signedToken2)
+
+		ws, _, err := websocket.DefaultDialer.Dial(fmt.Sprintf(chatRoomPath, addr.String(), validChatRoomID, tokenQuery2), nil)
 		if err != nil {
 			assert.Fail(t, err.Error())
 		}

--- a/messaging/usecase/message_usecase.go
+++ b/messaging/usecase/message_usecase.go
@@ -34,7 +34,6 @@ func (u *messageUseCase) IsAuthorized(ctx context.Context, userID, roomID string
 	_, cancel := context.WithTimeout(context.Background(), u.timeout)
 	defer cancel()
 
-	return true
 	studentChatRooms, err := u.roomRepository.GetRoomsFor(ctx, userID)
 	if err != nil {
 		return false


### PR DESCRIPTION
### Description
In this PR, the jwt token is extract from the query parameter in the websocket URL from the client. We use the token to get the issuer ID and use that to authorize the user; whether they are part of the room or not. This solution is meant to make the app more cohesive rather than secure.

Drawbacks: Since the URL is exposed, it is vulnerable to security attacks. Research was done to look into more secure methods to transfer the jwt token for websockets. More time is needed to attempt these, preferably in its own PR:
- use TLS, it's possible with k8 ingress
- Socket.io

### Testing
Unit Testing was added for isAuthorized.
The API was tested with a temporary client file because Postman was giving me an EOF error for websocket call.