### PR TITLE
add max participants to room

### DIFF
--- a/domain/chat_room.go
+++ b/domain/chat_room.go
@@ -7,12 +7,13 @@ import (
 
 // ChatRoom struct
 type ChatRoom struct {
-	RoomID   string    `json:"room_id"`
-	Name     string    `json:"name"`
-	Admin    Student   `json:"admin"`
-	Deleted  time.Time `json:"deleted"`
-	Students []Student `json:"students"`
-	Class    string    `json:"class"`
+	RoomID   		string    `json:"room_id"`
+	Name     		string    `json:"name"`
+	Admin    		Student   `json:"admin"`
+	Deleted  		time.Time `json:"deleted"`
+	Students 		[]Student `json:"students"`
+	Class    		string    `json:"class"`
+	MaxParticipants int 	  `json:"max_participants"`
 }
 
 // StudentChatRooms struct

--- a/messaging/repository/preparekeyspace/cassandra_chat_schema.cql
+++ b/messaging/repository/preparekeyspace/cassandra_chat_schema.cql
@@ -16,7 +16,8 @@ CREATE TABLE IF NOT EXISTS  chat.room (
     Admin text,
     students map<text, boolean>, -- map< userID, isPendingState >
     deleted timestamp,
-    class text
+    class text,
+    maxParticipants int
 );
 
 CREATE TABLE IF NOT EXISTS chat.student_rooms (
@@ -33,10 +34,10 @@ CREATE TABLE IF NOT EXISTS chat.student (
 
 -- michael is eaf54fae-1ab8-4b5a-8047-51904f6ae884
 -- dwight is 172ff420-f0eb-4d75-a26b-8d058a8499ec
-INSERT INTO chat.room (roomid, admin, name, students, class) VALUES ('office', 'eaf54fae-1ab8-4b5a-8047-51904f6ae884', 'office', {'eaf54fae-1ab8-4b5a-8047-51904f6ae884': false, 'toby': false, '172ff420-f0eb-4d75-a26b-8d058a8499ec': false}, 'soen490');
+INSERT INTO chat.room (roomid, admin, name, students, class, maxParticipants) VALUES ('office', 'eaf54fae-1ab8-4b5a-8047-51904f6ae884', 'office', {'eaf54fae-1ab8-4b5a-8047-51904f6ae884': false, 'toby': false, '172ff420-f0eb-4d75-a26b-8d058a8499ec': false}, 'soen490', 5);
 INSERT INTO chat.student_rooms (student, rooms) VALUES ('eaf54fae-1ab8-4b5a-8047-51904f6ae884', {'office'});
 INSERT INTO chat.student_rooms (student, rooms) VALUES ('toby', {'office'});
-INSERT INTO chat.room (roomid, admin, name, students, class) VALUES ('allstars', '172ff420-f0eb-4d75-a26b-8d058a8499ec' , 'allstars', {'172ff420-f0eb-4d75-a26b-8d058a8499ec': false, 'jim': false}, 'soen385');
+INSERT INTO chat.room (roomid, admin, name, students, class, maxParticipants) VALUES ('allstars', '172ff420-f0eb-4d75-a26b-8d058a8499ec' , 'allstars', {'172ff420-f0eb-4d75-a26b-8d058a8499ec': false, 'jim': false}, 'soen385', 5);
 INSERT INTO chat.student_rooms (student, rooms) VALUES ('172ff420-f0eb-4d75-a26b-8d058a8499ec', {'allstars', 'office'});
 INSERT INTO chat.student_rooms (student, rooms) VALUES ('jim', {'allstars'});
 INSERT INTO chat.student (student_id, first_name, last_name, email) VALUES ('jim', 'jim', 'halpert', 'jimhalpert@gmail.com');

--- a/room/repository/roomrepository_test.go
+++ b/room/repository/roomrepository_test.go
@@ -53,7 +53,7 @@ func TestGetRoomSuccessEmptyRoom(t *testing.T) {
 	sessionMock.On("Query", mock.Anything, mock.Anything).Return(queryMock)
 	queryMock.On("WithContext", ctx).Return(queryMock)
 	queryMock.On("Consistency", mock.Anything).Return(queryMock)
-	queryMock.On("Scan", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	queryMock.On("Scan", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	_, err := rr.GetRoom(ctx, mock.Anything)
 
@@ -68,7 +68,7 @@ func TestGetRoomFail(t *testing.T) {
 	sessionMock.On("Query", mock.Anything, mock.Anything).Return(queryMock)
 	queryMock.On("WithContext", ctx).Return(queryMock)
 	queryMock.On("Consistency", mock.Anything).Return(queryMock)
-	queryMock.On("Scan", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New(internalErrorMessage))
+	queryMock.On("Scan", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New(internalErrorMessage))
 
 	_, err := rr.GetRoom(ctx, mock.Anything)
 
@@ -273,7 +273,7 @@ func TestGetChatRoomsByClassSuccess(t *testing.T) {
 	queryMock.On("Iter").Return(mockIter)
 	mockIter.On("Scanner").Return(scannerMock)
 	scannerMock.On("Next").Return(true).Once()
-	scannerMock.On("Scan", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	scannerMock.On("Scan", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil).Once()
 	scannerMock.On("Next").Return(false).Once()
 	scannerMock.On("Err").Return(nil).Once()
@@ -293,7 +293,7 @@ func TestGetChatRoomsByClassFailScan(t *testing.T) {
 	mockIter.On("Scanner").Return(scannerMock)
 	scannerMock.On("Next").Return(true).Once()
 
-	scannerMock.On("Scan", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	scannerMock.On("Scan", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(errors.New(internalErrorMessage)).Once()
 
 	if _, err := rr.GetChatRoomsByClass(ctx, mock.Anything); err == nil {
@@ -310,7 +310,7 @@ func TestGetChatRoomsByClassFailCloseScan(t *testing.T) {
 	queryMock.On("Iter").Return(mockIter)
 	mockIter.On("Scanner").Return(scannerMock)
 	scannerMock.On("Next").Return(true).Once()
-	scannerMock.On("Scan", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	scannerMock.On("Scan", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil)
 	scannerMock.On("Next").Return(false).Once()
 	scannerMock.On("Err").Return(errors.New(internalErrorMessage))

--- a/room/usecase/room_usecase.go
+++ b/room/usecase/room_usecase.go
@@ -118,6 +118,7 @@ func (u *roomUseCase) GetChatRoomsFor(ctx context.Context, userID string) (*doma
 		studentChatRooms.Rooms[i].Name = room.Name
 		studentChatRooms.Rooms[i].Students = room.Students
 		studentChatRooms.Rooms[i].Deleted = room.Deleted
+		studentChatRooms.Rooms[i].MaxParticipants = room.MaxParticipants
 
 		for j := range studentChatRooms.Rooms[i].Students {
 			student, err = u.sr.GetStudent(ctx, studentChatRooms.Rooms[i].Students[j].ID)


### PR DESCRIPTION
Frontend wants to display the occupancy and availabilities of a team/chatroom so the max_participants attribute was added to address this.
Tested locally and on concordia server.