### PR TITLE
Decrease ping period to keep socket alive

### DIFF
--- a/messaging/delivery/http/chat_delivery.go
+++ b/messaging/delivery/http/chat_delivery.go
@@ -103,7 +103,7 @@ func NewHub() hub {
 const (
 	maxMessageSize int64 = 1024
 	pongWait             = time.Minute * 5
-	pingPeriod           = time.Minute * 5
+	pingPeriod           = time.Minute * 4
 	writeWait            = time.Minute
 )
 


### PR DESCRIPTION
Before, both ping and pong were the same so the connection dies while waiting for pong from the client as there was no time difference between ping and pong. Fixed in this commit