### PR TITLE
handle maxparticipants on add user to room

### DIFF
--- a/domain/chat_room.go
+++ b/domain/chat_room.go
@@ -53,7 +53,7 @@ type RoomRepository interface {
 type RoomUseCase interface {
 	// SaveRoom needs to save not just the room, but also add the chatroom for all the students
 	SaveRoom(ctx context.Context, room *ChatRoom) error
-	AddUserToRoom(ctx context.Context, roomID string, userID string) error
+	AddUserToRoom(ctx context.Context, roomID string, userID string, loggedID string) error
 	RemoveUserFromRoom(ctx context.Context, roomID string, userID string, loggedID string) error
 	GetChatRoomsByClass(ctx context.Context, className string) ([]ChatRoom, error)
 	GetChatRoomsFor(ctx context.Context, userID string) (*StudentChatRooms, error)

--- a/domain/mocks/RoomUseCase.go
+++ b/domain/mocks/RoomUseCase.go
@@ -14,13 +14,13 @@ type RoomUseCase struct {
 	mock.Mock
 }
 
-// AddUserToRoom provides a mock function with given fields: ctx, roomID, userID
-func (_m *RoomUseCase) AddUserToRoom(ctx context.Context, roomID string, userID string) error {
-	ret := _m.Called(ctx, roomID, userID)
+// AddUserToRoom provides a mock function with given fields: ctx, roomID, userID, loggedID
+func (_m *RoomUseCase) AddUserToRoom(ctx context.Context, roomID string, userID string, loggedID string) error {
+	ret := _m.Called(ctx, roomID, userID, loggedID)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(ctx, roomID, userID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = rf(ctx, roomID, userID, loggedID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -88,7 +88,7 @@ func (_m *RoomUseCase) GetChatRoomsFor(ctx context.Context, userID string) (*dom
 	return r0, r1
 }
 
-// RemoveUserFromRoom provides a mock function with given fields: ctx, roomID, userID
+// RemoveUserFromRoom provides a mock function with given fields: ctx, roomID, userID, loggedID
 func (_m *RoomUseCase) RemoveUserFromRoom(ctx context.Context, roomID string, userID string, loggedID string) error {
 	ret := _m.Called(ctx, roomID, userID, loggedID)
 

--- a/room/delivery/http/room_delivery.go
+++ b/room/delivery/http/room_delivery.go
@@ -44,11 +44,13 @@ func (h *RoomHandler) SaveRoom(c *gin.Context) {
 }
 
 func (h *RoomHandler) AddUserToRoom(c *gin.Context) {
+	key, _ := c.Get("loggedID")
+	loggedID, _ := key.(string)
 	userID := c.Params.ByName("id")
 	roomID := c.Params.ByName("roomID")
 
 	ctx := c.Request.Context()
-	err := h.u.AddUserToRoom(ctx, roomID, userID)
+	err := h.u.AddUserToRoom(ctx, roomID, userID, loggedID)
 	if err != nil {
 		errors.SetRESTError(err, c)
 		return

--- a/room/delivery/http/roomdelivery_test.go
+++ b/room/delivery/http/roomdelivery_test.go
@@ -97,7 +97,7 @@ func TestAddUserToRoom(t *testing.T) {
 
 	t.Run("AddUserToRoom Success", func(t *testing.T) {
 		mockRoomUseCase.
-			On("AddUserToRoom", mock.Anything, mock.Anything, mock.Anything).
+			On("AddUserToRoom", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(nil).
 			Once()
 
@@ -117,7 +117,7 @@ func TestAddUserToRoom(t *testing.T) {
 
 	t.Run("Fail: AddUserToRoom error", func(t *testing.T) {
 		mockRoomUseCase.
-			On("AddUserToRoom", mock.Anything, mock.Anything, mock.Anything).
+			On("AddUserToRoom", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(errors.NewInternalServerError("")).
 			Once()
 


### PR DESCRIPTION
This PR addresses the adding of participants to a room taking into account the max # of participants allowed. The caller can add a user to the room if all conditions are fulfilled:
- Caller is admin of the room
- The number of participants in the room with the attribute isPending=false is less than the room's allowed capacity

Tested locally and fixed/added unit tests.