### PR TITLE
Messaging/remove body from delete and make timestamp param

### DIFF
--- a/app/mapUrls.go
+++ b/app/mapUrls.go
@@ -3,6 +3,7 @@ package app
 import (
 	"chat/messaging/delivery/http"
 	roomHttp "chat/room/delivery/http"
+	"fmt"
 	"github.com/gin-gonic/gin"
 )
 
@@ -19,7 +20,7 @@ func mapChatUrls(mw Middleware, r *gin.Engine, mh *http.MessageHandler) {
 	const pathRoomID = "chat/:roomID"
 	router.POST(pathRoomID, mh.LoadMessages)
 	router.PUT(pathRoomID, mh.EditMessage)
-	router.DELETE(pathRoomID, mh.DeleteMessage)
+	router.DELETE(fmt.Sprintf("%s/:timestamp", pathRoomID), mh.DeleteMessage)
 	router.POST("chat/joinRequest/:roomID", mh.JoinRequest)
 	router.POST("chat/rejectRequest/:roomID/:userID", mh.RejectJoinRequest)
 }

--- a/domain/message.go
+++ b/domain/message.go
@@ -27,7 +27,7 @@ type MessageUseCase interface {
 	SaveMessage(ctx context.Context, message *Message) error
 	EditMessage(ctx context.Context, roomID string, userID string, timeStamp time.Time, message string) (*Message, error)
 	GetMessages(ctx context.Context, roomID string, timeStamp time.Time, limit int) ([]Message, error)
-	DeleteMessage(ctx context.Context, roomID string, timeStamp time.Time, userID string) error
+	DeleteMessage(ctx context.Context, roomID string, timeStamp time.Time, userID string) (*Message, error)
 	IsAuthorized(ctx context.Context, userID, roomID string) bool
 	JoinRequest(ctx context.Context, roomID string, userID string, timeStamp time.Time) error
 	SendRejection(ctx context.Context, roomID string, userID string, loggedID string) error

--- a/domain/mocks/MessageUseCase.go
+++ b/domain/mocks/MessageUseCase.go
@@ -17,17 +17,26 @@ type MessageUseCase struct {
 }
 
 // DeleteMessage provides a mock function with given fields: ctx, roomID, timeStamp, userID
-func (_m *MessageUseCase) DeleteMessage(ctx context.Context, roomID string, timeStamp time.Time, userID string) error {
+func (_m *MessageUseCase) DeleteMessage(ctx context.Context, roomID string, timeStamp time.Time, userID string) (*domain.Message, error) {
 	ret := _m.Called(ctx, roomID, timeStamp, userID)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, time.Time, string) error); ok {
+	var r0 *domain.Message
+	if rf, ok := ret.Get(0).(func(context.Context, string, time.Time, string) *domain.Message); ok {
 		r0 = rf(ctx, roomID, timeStamp, userID)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*domain.Message)
+		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, time.Time, string) error); ok {
+		r1 = rf(ctx, roomID, timeStamp, userID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // EditMessage provides a mock function with given fields: ctx, roomID, userID, timeStamp, message

--- a/messaging/usecase/message_usecase_test.go
+++ b/messaging/usecase/message_usecase_test.go
@@ -207,10 +207,11 @@ func TestDeleteMessage(t *testing.T) {
 			On("GetMessage", mock.Anything, mock.AnythingOfType("string"), mock.Anything).
 			Return(&mockMessage, nil).Once()
 
-		err := u.DeleteMessage(context.TODO(), mockMessage.RoomID, mockMessage.SentTimestamp, mockMessage.FromStudentID)
+		returnedMessage, err := u.DeleteMessage(context.TODO(), mockMessage.RoomID, mockMessage.SentTimestamp, mockMessage.FromStudentID)
 
+		mockMessage.MessageBody = ""
 		assert.NoError(t, err)
-
+		assert.EqualValues(t, mockMessage, *returnedMessage)
 		mockMessageRepository.AssertExpectations(t)
 	})
 
@@ -219,9 +220,10 @@ func TestDeleteMessage(t *testing.T) {
 			On("GetMessage", mock.Anything, mock.AnythingOfType("string"), mock.Anything).
 			Return(nil, errors.New("error")).Once()
 
-		err := u.DeleteMessage(context.TODO(), mockMessage.RoomID, mockMessage.SentTimestamp, mockMessage.FromStudentID)
+		msg, err := u.DeleteMessage(context.TODO(), mockMessage.RoomID, mockMessage.SentTimestamp, mockMessage.FromStudentID)
 
 		assert.Error(t, err)
+		assert.Nil(t, msg)
 
 		mockMessageRepository.AssertExpectations(t)
 	})
@@ -233,9 +235,10 @@ func TestDeleteMessage(t *testing.T) {
 			On("GetMessage", mock.Anything, mock.AnythingOfType("string"), mock.Anything).
 			Return(&msg, nil).Once()
 
-		err := u.DeleteMessage(context.TODO(), mockMessage.RoomID, mockMessage.SentTimestamp, mockMessage.FromStudentID)
+		message, err := u.DeleteMessage(context.TODO(), mockMessage.RoomID, mockMessage.SentTimestamp, mockMessage.FromStudentID)
 
 		assert.Error(t, err)
+		assert.Nil(t, message)
 
 		mockMessageRepository.AssertExpectations(t)
 
@@ -250,9 +253,10 @@ func TestDeleteMessage(t *testing.T) {
 			On("GetMessage", mock.Anything, mock.AnythingOfType("string"), mock.Anything).
 			Return(&mockMessage, nil).Once()
 
-		err := u.DeleteMessage(context.TODO(), mockMessage.RoomID, mockMessage.SentTimestamp, mockMessage.FromStudentID)
+		message, err := u.DeleteMessage(context.TODO(), mockMessage.RoomID, mockMessage.SentTimestamp, mockMessage.FromStudentID)
 
 		assert.Error(t, err)
+		assert.Nil(t, message)
 
 		mockMessageRepository.AssertExpectations(t)
 	})


### PR DESCRIPTION
- Change timestamp being parsed from the request body to be given by param instead
- Return a message from DeleteMessage method in usecase so it can be used by by websocket